### PR TITLE
Remoce spaces from column name

### DIFF
--- a/src/DataMasker/DataSources/SqlDataSource.cs
+++ b/src/DataMasker/DataSources/SqlDataSource.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using DataMasker.Interfaces;
 using DataMasker.Models;
 using DataMasker.Utils;
+using System.Text.RegularExpressions;
 
 namespace DataMasker.DataSources
 {
@@ -102,9 +103,19 @@ namespace DataMasker.DataSources
                 {
                     SqlTransaction sqlTransaction = connection.BeginTransaction();
 
-
                     string sql = BuildUpdateSql(config);
-                    connection.Execute(sql, batch.Items, sqlTransaction, null, CommandType.Text);
+					//remove any spaces from variables
+					var newBatch = new List<Dictionary<string, object>>();
+					foreach (var item in batch.Items)
+					{
+						var newItem = new Dictionary<string, object>();
+						foreach (var key in item.Keys)
+						{
+							newItem.Add(Regex.Replace(key, @"\s+", "_"), item[key]);
+						}
+						newBatch.Add(newItem);
+					}
+                    connection.Execute(sql, newBatch, sqlTransaction, null, CommandType.Text);
 
                     if (_sourceConfig.DryRun)
                     {

--- a/src/DataMasker/Extensions.cs
+++ b/src/DataMasker/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using DataMasker.Models;
 
 namespace DataMasker
@@ -37,7 +38,7 @@ namespace DataMasker
             return string.Join(
                                ", ",
                                columns.Where(x => !x.Ignore)
-                                      .Select(x => $"[{x.Name}] = @{paramPrefix}{x.Name}"));
+                                      .Select(x => $"[{x.Name}] = @{paramPrefix}{Regex.Replace(x.Name, @"\s+", "_")}"));
         }
     }
 }


### PR DESCRIPTION
Some old databases has spaces in columns' names when the tool generates the sql statements it create a variables with spaces such as @Contact Name and this row exception when executing the query
I have removed the spaces from columns before generating variable names.