### PR TITLE
Allow the runner to run at native bitness

### DIFF
--- a/src/DataMasker.Runner/DataMasker.Runner.csproj
+++ b/src/DataMasker.Runner/DataMasker.Runner.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
This disables the "Prefer32Bit" flag so the runner will run as a 64-bit process on 64-bit machines (and thus prevent `OutOfMemoryExceptions` when processing large tables).
Related issue: https://github.com/Steveiwonder/DataMasker/issues/20