### PR TITLE
Make database access lazy

### DIFF
--- a/src/DataMasker.Examples/Program.cs
+++ b/src/DataMasker.Examples/Program.cs
@@ -36,16 +36,18 @@ namespace DataMasker.Examples
             foreach (TableConfig tableConfig in config.Tables)
             {
                 IEnumerable<IDictionary<string, object>> rows = dataSource.GetData(tableConfig);
-                foreach (IDictionary<string, object> row in rows)
+                var rowCount = dataSource.GetCount(tableConfig);
+
+                var masked = rows.Select(row =>
                 {
-                    dataMasker.Mask(row, tableConfig);
+                    return dataMasker.Mask(row, tableConfig);
 
                     //update per row
                     //dataSource.UpdateRow(row, tableConfig);
-                }
+                });
 
                 //update all rows
-                dataSource.UpdateRows(rows, tableConfig);
+                dataSource.UpdateRows(masked, rowCount, tableConfig);
             }
         }
 

--- a/src/DataMasker/DataSources/InMemoryFakeDataSource.cs
+++ b/src/DataMasker/DataSources/InMemoryFakeDataSource.cs
@@ -90,6 +90,7 @@ namespace DataMasker.DataSources
         /// <inheritdoc/>
         public void UpdateRows(
             IEnumerable<IDictionary<string, object>> rows,
+            int rowCount,
             TableConfig config,
             Action<int> updatedCallback)
         {
@@ -98,6 +99,11 @@ namespace DataMasker.DataSources
             {
                 UpdateRow(dictionary, config);
             }
+        }
+
+        public int GetCount(TableConfig config)
+        {
+            return tableData.Count;
         }
     }
 }

--- a/src/DataMasker/Interfaces/IDataSource.cs
+++ b/src/DataMasker/Interfaces/IDataSource.cs
@@ -37,7 +37,10 @@ namespace DataMasker.Interfaces
         /// </param>
         void UpdateRows(
             IEnumerable<IDictionary<string, object>> rows,
+            int rowCount,
             TableConfig config,
             Action<int> updatedCallback = null);
+
+        int GetCount(TableConfig config);
     }
 }

--- a/src/DataMasker/Utils/Batch.cs
+++ b/src/DataMasker/Utils/Batch.cs
@@ -43,16 +43,14 @@ namespace DataMasker.Utils
         /// </param>
         /// <returns></returns>
         public static IEnumerable<Batch<T>> BatchItems(
-            T[] items,
+            IEnumerable<T> items,
             Func<T, IEnumerable<T>, bool> addToCurrentBatchPredicate)
         {
             int currentBatchNo = 1;
-            List<Batch<T>> batchedItems = new List<Batch<T>>();
             Batch<T> currentBatch = new Batch<T>(currentBatchNo);
 
-            for (int i = 0; i < items.Length; i++)
+            foreach (var item in items)
             {
-                T item = items[i];
                 bool addToCurrentBatch = addToCurrentBatchPredicate(item, currentBatch.Items);
 
                 if (addToCurrentBatch)
@@ -61,14 +59,13 @@ namespace DataMasker.Utils
                 }
                 else
                 {
-                    batchedItems.Add(currentBatch);
+                    yield return currentBatch;
                     currentBatch = new Batch<T>(++currentBatchNo);
                     currentBatch.AddItem(item);
                 }
             }
 
-            batchedItems.Add(currentBatch);
-            return batchedItems;
+            yield return currentBatch;
         }
     }
 }


### PR DESCRIPTION
The runner tends to run out of memory with large datasets.

This PR addresses this by:
- Changing the Dapper `Query` call to not use [buffering](https://dapper-tutorial.net/buffered), i.e. to "stream" the rows via `IEnumerable`
- Adding an explicit `GetCount` method to `IDataSource` to allow tracking of percentage completion when rows are no longer retrieved in advance
- Updating `Batch.BatchItems` to use `yield` rather than creating a collection in memory

_This PR is very open to change - it's more of a statement of an idea than the "only" way to solve the problem. That having been said, it_ does _work, and I have used it to mask tables with 36M+ rows_.

Issue: https://github.com/Steveiwonder/DataMasker/issues/23