### PR TITLE
Add RetainEmptyStringValues column config

### DIFF
--- a/src/DataMasker/DataGenerator.cs
+++ b/src/DataMasker/DataGenerator.cs
@@ -79,11 +79,16 @@ namespace DataMasker
                 return ConvertValue(columnConfig.Type, columnConfig.UseValue);
             }
 
-
             if (columnConfig.RetainNullValues &&
                 existingValue == null)
             {
                 return null;
+            }
+
+            if (columnConfig.RetainEmptyStringValues &&
+                (existingValue is string && (string.IsNullOrWhiteSpace((string)existingValue))))
+            {
+                return existingValue;
             }
 
             if (existingValue == null)

--- a/src/DataMasker/Models/ColumnConfig.cs
+++ b/src/DataMasker/Models/ColumnConfig.cs
@@ -114,6 +114,17 @@ namespace DataMasker.Models
     public bool RetainNullValues { get; set; }
 
     /// <summary>
+    /// When true, if the data loaded from the source is an empty string (String.IsNullOrWhitespace), then no new data will be generated.
+    /// When false, if the data loaded from the source is an empty string (String.IsNullOrWhitespace) it will be replaced by new data
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if [retain empty values]; otherwise, <c>false</c>.
+    /// </value>
+    [DefaultValue(false)]
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+    public bool RetainEmptyStringValues { get; set; }
+
+    /// <summary>
     /// When true, mappings specific to this column will be used
     /// <remarks>
     /// If you have 10 rows of data each with column "Surname" and you will for all the people with the same surname


### PR DESCRIPTION
In our masking tasks, we would like the ability to retain string values that are empty (string.IsNullOrWhiteSpace) without masking them, since they usually don't require masking when empty. Otherwise we end up writing for example a full Lorem text to every column, even when that value is empty.

I've set the new "RetainEmptyStringValues" to default to false so that it does not cause unexpected behaviour with existing configurations.