### PR TITLE
readme: fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Example Usage
 Config config = Config.Load($"example-configs\\config-example1.json");
 
 //create a data masker
-IDataMasker dataMasker = new DataMasker(new DataGenerator(config.DataGeneration));
+IDataMasker dataMasker = new DataMasker.DataMasker(new DataGenerator(config.DataGeneration));
 
 //grab our dataSource from the config, note: you could just ignore the config.DataSource.Type
 //and initialize your own instance

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Only some data types currently use the min/max properties on the column configur
 Example Usage
 ```csharp
 //load our configuration
-Config config = Config.Load($"example-configs\\config-example1.json")
+Config config = Config.Load($"example-configs\\config-example1.json");
 
 //create a data masker
 IDataMasker dataMasker = new DataMasker(new DataGenerator(config.DataGeneration));
@@ -336,17 +336,18 @@ foreach (TableConfig tableConfig in config.Tables)
 {
     //load the data, this needs optimizing for large tables
     IEnumerable<IDictionary<string, object>> rows = dataSource.GetData(tableConfig);
+    var masked = new List<IDictionary<string, object>>();
     foreach (IDictionary<string, object> row in rows)
     {
         //mask each row
-        dataMasker.Mask(row, tableConfig);
+        masked.Add(dataMasker.Mask(row, tableConfig));
 
         //update per row, or see below,
         //dataSource.UpdateRow(row, tableConfig);
     }
 
     //update all rows, in batches of 100
-    dataSource.UpdateRows(rows, tableConfig, 100);
+    dataSource.UpdateRows(masked, 100, tableConfig);
 }
 
 ```


### PR DESCRIPTION
- fix missing semi colon
- batch update with the original iEnumerable does not work because of "multiple enumeration" thus store the masked result in a new list

