### PR TITLE
allow json content to be passed directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ Example Usage
 ```csharp
 //load our configuration
 Config config = Config.Load($"example-configs\\config-example1.json")
+// you also can pass the JSON content directly:
+// Config config = Config.LoadFromString(....);
 
 //create a data masker
 IDataMasker dataMasker = new DataMasker(new DataGenerator(config.DataGeneration));

--- a/src/DataMasker/Models/Config.cs
+++ b/src/DataMasker/Models/Config.cs
@@ -43,8 +43,13 @@ namespace DataMasker.Models
         public static Config Load(
             string filePath)
         {
+            return LoadFromString(File.ReadAllText(filePath));
+        }
+
+        public static Config LoadFromString(string jsonContent)
+        {
             Config config = new Config();
-            JsonConvert.PopulateObject(File.ReadAllText(filePath), config);
+            JsonConvert.PopulateObject(jsonContent, config);
             if (config.DataGeneration == null)
             {
                 config.DataGeneration = new DataGenerationConfig();


### PR DESCRIPTION
I would like to add another method for loading json.

My usecase:
Defining all the columns and tables in one json is fine, but currently I try this project with a project with about 100 tables. Defining all the columns for those tables in one file feels wrong and I think it is also harder to maintain.

So I do following:

+ create a folder "ColumnDefinitions"
+ modify the config:
```
{
  "dataSource": {
    ....
    }
  },
  "generic-column-def": {
    "name": "?",
    "schema": "dbo",
    "primaryKeyColumn": "Id"
  },
  "tables": [
  ]
}
```
+ add a file for every table in "ColumnDefinitions" folder
+ merge the base config with all partial configs+ pass this to DataMasker

Currently this is not possible because it only accepts a file path. So I added the possibility to pass the JSON content directly.
