### PR TITLE
Allow table configuration to be loaded in via an external json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ Example Usage
 ```csharp
 //load our configuration
 Config config = Config.Load($"example-configs\\config-example1.json")
+// you also can pass the JSON content directly:
+// Config config = Config.LoadFromString(....);
 
 //create a data masker
 IDataMasker dataMasker = new DataMasker(new DataGenerator(config.DataGeneration));

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ DataMasker is available as a library over on [nuget.org](https://www.nuget.org/p
 >install-package DataMasker
 
 ## Configuration
-All configuration is done via a .json file, the schema can be found here: [json schema](https://github.com/Steveiwonder/DataMasker/blob/master/src/DataMasker.Config.schema.json)
+All configuration is done via a .json file, of which an example can be seen below.
 
 Example Config
 ```json
@@ -30,7 +30,7 @@ Example Config
        "password": "databasePassword",
        "server": "databaseServer"
     }   
-  },
+  },  
   "tables": [    
     {
       "name": "Users",
@@ -92,6 +92,43 @@ Example Config
   ]
 }
 ```
+
+Table configuration is supplied by either the "tables" property or "tablesConfigPath" property.
+
+If you want to keep your table configuration external to the main .json file this can be done by supplying "tablesConfigPath" with a file path. An example of this can be found in the example-configs directory in the example project.
+
+External table config json
+```json
+{
+    "dataSource": {
+    "type": "SqlServer",
+    "config": {
+       "name": "databasename",
+       "userName": "databaseUserName",
+       "password": "databasePassword",
+       "server": "databaseServer"
+    }   
+  }, 
+  "tablesConfigPath": "example-configs\\config-example2-table-config.json",
+}
+```
+or embedded
+```json
+{
+    "dataSource": {
+    "type": "SqlServer",
+    "config": {
+       "name": "databasename",
+       "userName": "databaseUserName",
+       "password": "databasePassword",
+       "server": "databaseServer"
+    }   
+  }, 
+  "tables": [... insert config here ...],
+}
+```
+
+If both `tables` and `tablesConfigPath` is supplied then `tablesConfigPath` wins.
 
 ## Column Configuration
 

--- a/src/DataMasker.Examples/DataMasker.Examples.csproj
+++ b/src/DataMasker.Examples/DataMasker.Examples.csproj
@@ -56,7 +56,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="example-configs\config-example2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="example-configs\config-example1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="example-configs\config-example2-table-config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />

--- a/src/DataMasker.Examples/Program.cs
+++ b/src/DataMasker.Examples/Program.cs
@@ -30,24 +30,46 @@ namespace DataMasker.Examples
         public static void Example1()
         {
             Config config = LoadConfig(1);
+
+            //create a data masker
             IDataMasker dataMasker = new DataMasker(new DataGenerator(config.DataGeneration));
+
+            //grab our dataSource from the config, note: you could just ignore the config.DataSource.Type
+            //and initialize your own instance
             IDataSource dataSource = DataSourceProvider.Provide(config.DataSource.Type, config.DataSource);
 
+            //enumerate all our tables
             foreach (TableConfig tableConfig in config.Tables)
             {
+                //load data
                 IEnumerable<IDictionary<string, object>> rows = dataSource.GetData(tableConfig);
+
+                //get row coun
                 var rowCount = dataSource.GetCount(tableConfig);
 
+
+                //here you have two options, you can update all rows in one go, or one at a time.
+                #region update all rows
+                //update all rows
                 var masked = rows.Select(row =>
                 {
+                    //mask the data
                     return dataMasker.Mask(row, tableConfig);
-
-                    //update per row
-                    //dataSource.UpdateRow(row, tableConfig);
                 });
-
-                //update all rows
+                
                 dataSource.UpdateRows(masked, rowCount, tableConfig);
+                #endregion
+                //OR
+                #region update row by row
+
+                foreach (var row in rows)
+                {
+                    //mask the data
+                    var maskedRow = dataMasker.Mask(row, tableConfig);
+                    dataSource.UpdateRow(maskedRow, tableConfig);
+                }
+
+                #endregion
             }
         }
 

--- a/src/DataMasker.Examples/example-configs/config-example2-table-config.json
+++ b/src/DataMasker.Examples/example-configs/config-example2-table-config.json
@@ -1,0 +1,58 @@
+﻿[
+  {
+    "name": "Users",
+    "primaryKeyColumn": "UserId",
+    "columns": [
+      {
+        "name": "FirstName",
+        "type": "FirstName",
+        "useGenderColumn": "Gender"
+      },
+      {
+        "name": "LastName",
+        "type": "LastName",
+        "retainEmptyStringValues": true,
+        "useGlobalValueMappings": true,
+        "valueMappings": {
+          "oldValue": "Jones",
+          "newValue": "Smith"
+        }
+      },
+      {
+        "name": "Password",
+        "type": "None",
+        "retainNullValues": false,
+        "useValue": "PasswordForDevEnvironment"
+      },
+      {
+        "name": "DOB",
+        "type": "DateOfBirth",
+        "min": "1950-01-01"
+      },
+      {
+        "name": "Gender",
+        "ignore": true,
+        "type": "None"
+      },
+      {
+        "name": "Address",
+        "type": "Bogus",
+        "stringFormatPattern": "{{address.fullAddress}}",
+        "retainNullValues": false
+      },
+      {
+        "name": "ContactNumber",
+        "type": "PhoneNumber",
+        "retainNullValues": false,
+        "stringFormatPattern": "+447#########"
+      },
+      {
+        "name": "Bio",
+        "type": "Lorem",
+        "retainNullValues": false,
+        "min": 5,
+        "max": 10
+      }
+    ]
+  }
+]

--- a/src/DataMasker.Examples/example-configs/config-example2.json
+++ b/src/DataMasker.Examples/example-configs/config-example2.json
@@ -1,0 +1,12 @@
+﻿{
+  "dataSource": {
+    "type": "SqlServer",
+    "config": {
+      "connectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=Clients;Integrated Security=SSPI;"
+    }
+  },
+  "dataGeneration": {
+    "locale": "en"
+  },
+  "tablesConfigPath": "example-configs\\config-example2-table-config.json"
+}

--- a/src/DataMasker/Models/Config.cs
+++ b/src/DataMasker/Models/Config.cs
@@ -43,8 +43,13 @@ namespace DataMasker.Models
         public static Config Load(
             string filePath)
         {
+            return LoadFromString(File.ReadAllText(filePath));
+        }
+
+        public static Config LoadFromString(string jsonContent)
+        {
             Config config = new Config();
-            JsonConvert.PopulateObject(File.ReadAllText(filePath), config);
+            JsonConvert.PopulateObject(jsonContent, config);
             if (config.DataGeneration == null)
             {
                 config.DataGeneration = new DataGenerationConfig();

--- a/src/DataMasker/Models/Config.cs
+++ b/src/DataMasker/Models/Config.cs
@@ -22,14 +22,7 @@ namespace DataMasker.Models
         /// </value>
         [JsonRequired]
         public DataSourceConfig DataSource { get; set; }
-
-        /// <summary>
-        /// Gets or sets the tables.
-        /// </summary>
-        /// <value>
-        /// The tables.
-        /// </value>
-        [JsonRequired]
+       
         public IList<TableConfig> Tables { get; set; }
 
         /// <summary>
@@ -39,17 +32,21 @@ namespace DataMasker.Models
         /// The data generation configuration.
         /// </value>
         public DataGenerationConfig DataGeneration { get; set; }
+        public string TablesConfigPath { get;  set; }
 
-        public static Config Load(
-            string filePath)
-        {
-            return LoadFromString(File.ReadAllText(filePath));
-        }
-
-        public static Config LoadFromString(string jsonContent)
+        public static Config Load(string filePath)  
         {
             Config config = new Config();
-            JsonConvert.PopulateObject(jsonContent, config);
+            JsonConvert.PopulateObject(File.ReadAllText(filePath), config);
+
+            if(config.Tables == null && string.IsNullOrEmpty(config.TablesConfigPath))
+            {
+                throw new Exception("Must supply table config, either via TableConfig or TableConfigPath");
+            }
+            if (!string.IsNullOrEmpty(config.TablesConfigPath))
+            {
+                config.Tables = JsonConvert.DeserializeObject<List<TableConfig>>(File.ReadAllText(config.TablesConfigPath));
+            }
             if (config.DataGeneration == null)
             {
                 config.DataGeneration = new DataGenerationConfig();


### PR DESCRIPTION
Now using the `tablesConfigPath` the table config can be loaded via an external file. For more info see examples and documentation