### PR TITLE
Fix missing Bogus as supported data type

### DIFF
--- a/src/DataMasker/BogusDataProvider.cs
+++ b/src/DataMasker/BogusDataProvider.cs
@@ -287,7 +287,8 @@ namespace DataMasker
       DataType.Lorem,
       DataType.FullAddress,
       DataType.PhoneNumber,
-      DataType.DateOfBirth,DataType.StringFormat,
+      DataType.DateOfBirth,
+      DataType.StringFormat,
       DataType.Bogus,
       DataType.None,
       };

--- a/src/DataMasker/BogusDataProvider.cs
+++ b/src/DataMasker/BogusDataProvider.cs
@@ -288,6 +288,7 @@ namespace DataMasker
       DataType.FullAddress,
       DataType.PhoneNumber,
       DataType.DateOfBirth,DataType.StringFormat,
+      DataType.Bogus,
       DataType.None,
       };
     public bool CanProvide(DataType dataType)


### PR DESCRIPTION
Currently, using Bogus datatype will throw exception as the supported data type is missing.  Add the missing supported data type Bogus Datatype to allow Bogus Datatype to be working.