### PR TITLE
added sqlstatements to mask/delete/truncate tables

### DIFF
--- a/src/DataMasker/DataMasker.cs
+++ b/src/DataMasker/DataMasker.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Bogus.DataSets;
+using DataMasker.DataSources;
 using DataMasker.Interfaces;
 using DataMasker.Models;
 
@@ -38,13 +39,16 @@ namespace DataMasker
       _dataProviders = dataProviders;
     }
 
-    /// <summary>
-    /// Masks the specified object with new data
-    /// </summary>
-    /// <param name="obj">The object to mask</param>
-    /// <param name="tableConfig">The table configuration.</param>
-    /// <returns></returns>
-    public IDictionary<string, object> Mask(
+
+  
+
+        /// <summary>
+        /// Masks the specified object with new data
+        /// </summary>
+        /// <param name="obj">The object to mask</param>
+        /// <param name="tableConfig">The table configuration.</param>
+        /// <returns></returns>
+        public IDictionary<string, object> Mask(
         IDictionary<string, object> obj,
         TableConfig tableConfig)
     {

--- a/src/DataMasker/DataSources/SqlStatementDataSource.cs
+++ b/src/DataMasker/DataSources/SqlStatementDataSource.cs
@@ -1,0 +1,57 @@
+using System;
+using Dapper;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using DataMasker.Interfaces;
+using DataMasker.Models;
+using DataMasker.Utils;
+
+namespace DataMasker.DataSources
+{
+    /// <summary>
+    /// SqlStatementDataSource
+    /// </summary>
+    /// <seealso cref="ISqlStatementDataSource"/>
+    public class SqlStatementDataSource : ISqlStatementDataSource
+    {
+        private readonly DataSourceConfig _sourceConfig;
+
+        private readonly string _connectionString;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlDataSource"/> class.
+        /// </summary>
+        /// <param name="sourceConfig"></param>
+        public SqlStatementDataSource(
+            DataSourceConfig sourceConfig)
+        {
+            _sourceConfig = sourceConfig;
+            _connectionString = sourceConfig.GetConnectionString();
+        }
+
+
+        /// <summary>
+        /// Executes sql statement
+        /// </summary>
+        /// <param name="sqlStatementConfig">The statement configuration.</param>
+        /// <inheritdoc/>
+        public void Execute(
+            SqlStatementConfig sqlStatementConfig)
+        {
+            if (!_sourceConfig.DryRun)
+            {
+                using (SqlConnection connection = new SqlConnection(_connectionString))
+                {
+                    connection.Open();
+                    var statementToExecute = sqlStatementConfig.Statement;
+                    connection.Execute(statementToExecute);
+
+                }
+            }
+        }
+
+
+    }
+}

--- a/src/DataMasker/Interfaces/ISqlStatementDataSource.cs
+++ b/src/DataMasker/Interfaces/ISqlStatementDataSource.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using DataMasker.Models;
+
+namespace DataMasker.Interfaces
+{
+    /// <summary>
+    /// ISqlStatementDataSource
+    /// </summary>
+    public interface ISqlStatementDataSource
+    {
+        /// <summary>
+        /// Gets the data.
+        /// </summary>
+        /// <param name="sqlStatementConfig">The statement configuration.</param>
+        /// <returns></returns>
+        void Execute(SqlStatementConfig sqlStatementConfig);
+
+    }
+}

--- a/src/DataMasker/Models/Config.cs
+++ b/src/DataMasker/Models/Config.cs
@@ -25,6 +25,9 @@ namespace DataMasker.Models
        
         public IList<TableConfig> Tables { get; set; }
 
+
+        public IList<SqlStatementConfig> SqlStatements { get; set; }
+
         /// <summary>
         /// Gets or sets the generation configuration.
         /// </summary>

--- a/src/DataMasker/Models/SqlStatementConfig.cs
+++ b/src/DataMasker/Models/SqlStatementConfig.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace DataMasker.Models
+{
+    /// <summary>
+    /// TableConfig
+    /// </summary>
+    public class SqlStatementConfig
+    {
+        /// <summary>
+        /// The name of the sql statement
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
+        [JsonRequired]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The sql statement to be executed angainst db
+        /// </summary>
+        /// <value>
+        /// The sql statement
+        /// </value>
+        [JsonRequired]
+        public string Statement { get; set; }
+
+    }
+}

--- a/src/DataMasker/SqlStatementDataProvier.cs
+++ b/src/DataMasker/SqlStatementDataProvier.cs
@@ -9,17 +9,16 @@ using DataMasker.Models;
 
 namespace DataMasker
 {
-    public static class DataSourceProvider
+    public static class SqlStatementDataProvier
     {
-        public static IDataSource Provide(
+        public static ISqlStatementDataSource Provide(
             DataSourceType dataSourceType, DataSourceConfig dataSourceConfig = null)
         {
             switch (dataSourceType)
             {
-                case DataSourceType.InMemoryFake:
-                    return new InMemoryFakeDataSource();
+
                 case DataSourceType.SqlServer:
-                    return new SqlDataSource(dataSourceConfig);
+                    return new SqlStatementDataSource(dataSourceConfig);
 
             }
 


### PR DESCRIPTION
If you are interested we developed an extra config .json files to execute arbitrary SQL statements during masking.
We use them to truncate tables on our db or to do some batch updates on them.

Have a look to sqlStatements on the following json example:



```
{
    "dataSource": {
        "type": "SqlServer",
        "config": {
            "connectionString": "Data Source=xxxxxxxxxxxxxxxxxxxxxxxx"
        }
    },
    "dataGeneration": {
        "locale": "it"
    },
    "tables": [
        {
            "name": "zero_table",
            "primaryKeyColumn": "id",
            "columns": [
              {
                "name": "Note",
                "type": "Sql",
                "sqlValue": {
                  "query": "select 1"
    
                }
              }
            ]
        }
    ],

    "sqlStatements": [
        {
            "name": "SqlVolante",
            "statement": "Truncate table first_table"
        },
        {
            "name": "SqlVolante1",
            "statement": "Truncate table second_table"
        }
    ]
}

```